### PR TITLE
feat: invalidate multiple expense-related queries after adding new ex…

### DIFF
--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -24,27 +24,18 @@ const ExpenseDashBoard = () => {
     paymentMethodId: "",
   });
 
-  const {
-    mutate: getSummary,
-    data: summaryData,
-    isPending: isSummaryLoading,
-  } = useGetExpenseSummary();
+  const { data: summaryData, isPending: isSummaryLoading } =
+    useGetExpenseSummary({ userId: id });
 
   const { data: expenseData, isLoading: isExpenseLoading } =
     useGetExpenses(pageData);
-
-  useEffect(() => {
-    if (id) {
-      getSummary({ userId: id });
-    }
-  }, [id]);
 
   const tableData = useMemo(() => {
     return {
       count: expenseData?.count || 0,
       data: expenseData?.resp || [],
     };
-  }, [expenseData]);
+  }, [expenseData, isExpenseLoading]);
 
   return (
     <div>

--- a/src/app/ClientProvider.tsx
+++ b/src/app/ClientProvider.tsx
@@ -2,14 +2,13 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React, { useState } from "react";
+export const queryClient = new QueryClient();
 
 export default function ClientProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const [queryClient] = useState(() => new QueryClient());
-
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );

--- a/src/components/OpenExpenseDrawerButton.tsx
+++ b/src/components/OpenExpenseDrawerButton.tsx
@@ -13,7 +13,7 @@ const OpenExpenseDrawerButton: React.FC<OpenExpenseDrawerButtonProps> = ({
     <DrawerTrigger asChild>
       <Button
         onClick={onClick}
-        className="bg-gradient-to-r from-purple-500 to-blue-600 hover:from-purple-600 hover:to-blue-700 text-white shadow-lg hover:shadow-xl transition-all duration-200"
+        className="bg-gradient-to-r cursor-pointer from-purple-500 to-blue-600 hover:from-purple-600 hover:to-blue-700 text-white shadow-lg hover:shadow-xl transition-all duration-200"
       >
         <Plus className="w-4 h-4 mr-2" />
         Add Expense

--- a/src/query/useAddExpense.ts
+++ b/src/query/useAddExpense.ts
@@ -1,3 +1,4 @@
+import { queryClient } from "@/app/ClientProvider";
 import { iExpenseFormData } from "@/interfaces/expense";
 import axiosConfig, { endpoints } from "@/lib";
 import { useMutation } from "@tanstack/react-query";
@@ -11,7 +12,14 @@ const useAddExpenseMutation = () => {
   return useMutation({
     mutationKey: ["expense:add"],
     mutationFn: addExpenseRequest,
-    retry: 3,
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["get-expenses"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["get-expense-summary"],
+      });
+    },
   });
 };
 

--- a/src/query/useGetExpenseSummary.ts
+++ b/src/query/useGetExpenseSummary.ts
@@ -1,5 +1,5 @@
 import axiosConfig, { endpoints } from "@/lib";
-import { useMutation } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
 interface ifetchExpenseSummary {
   userId: string;
@@ -12,11 +12,11 @@ const fetchExpenseSummary = async (data: ifetchExpenseSummary) => {
   return resp.data;
 };
 
-const useGetExpenseSummary = () => {
-  return useMutation({
-    mutationKey: ["get-expense-summary"],
-    mutationFn: fetchExpenseSummary,
-    retry: 3,
+const useGetExpenseSummary = (params: ifetchExpenseSummary) => {
+  return useQuery({
+    queryKey: ["get-expense-summary", params?.userId],
+    queryFn: () => fetchExpenseSummary(params),
+    staleTime: 1000 * 60 * 1,
   });
 };
 


### PR DESCRIPTION
- Updated `useAddExpenseMutation` hook to revalidate multiple queries upon mutation settle.
- Now invalidating:
  - `get-expense-summary`
  - `get-expenses`
- Ensures dashboard and reports stay in sync after adding a new expense.
